### PR TITLE
Double quotes on titles brakes twitter button

### DIFF
--- a/neat/templates/article.html
+++ b/neat/templates/article.html
@@ -34,7 +34,7 @@
     {% elif TWITTER_USERNAME %}
     <div class="share">
         <a href="https://twitter.com/share" class="twitter-share-button"
-           data-count="horizontal" data-text="{{ article.title|striptags }}"
+           data-count="horizontal" data-text="{{ article.title|striptags|escape }}"
            data-via="{{ TWITTER_USERNAME }}">Tweet</a>
     </div>
     <script src="//platform.twitter.com/widgets.js"></script>


### PR DESCRIPTION
Article titles that has double quotes, brakes twitter button's data-text attribute. I added [escape filter](http://jinja.pocoo.org/docs/templates/#escape) to generation of data-text attribute to solve that.
