### PR TITLE
Adding SITEURL where it was missing

### DIFF
--- a/neat/templates/article_header.html
+++ b/neat/templates/article_header.html
@@ -1,4 +1,4 @@
-<h2><a href="{{ article.url }}" rel="bookmark">
+<h2><a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark">
     {{ article.title|striptags }}
 </a></h2>
 <time datetime="{{ article.date }}" pubdate>Posted on

--- a/neat/templates/base.html
+++ b/neat/templates/base.html
@@ -24,7 +24,7 @@
     <header id="main">
         <div class="container">
             <div class="logo">
-                <a href="index.html" title="Home">{{ SITENAME }}</a>
+                <a href="{{ SITEURL }}/index.html" title="Home">{{ SITENAME }}</a>
             </div>
         </div>
     </header>
@@ -90,7 +90,7 @@
             </span>
             <nav>
                 <ul>
-                    <li><a href="archives.html" title="Archive"><strong>Archive</strong></a></li>
+                    <li><a href="{{ SITEURL }}/archives.html" title="Archive"><strong>Archive</strong></a></li>
                     {% if SITE_SOURCE %}
                     <li><a href="{{ SITE_SOURCE }}" title="Source code">Source code</a></li>
                     {% endif %}


### PR DESCRIPTION
When you are in 2nd level pages like category/somecategory.html or
author/someauthor.html the index and article titles had broken URLs
because SITEURL was missing in the templates.
